### PR TITLE
New scales: varia aku series

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This allows for easy extention of the library for more bluetooth enabled scales.
 * [Acaia Lunar](https://acaia.co/collections/coffee-scales/products/lunar_2021) - [Tested]
 * [Acaia Pearl](https://acaia.co/collections/coffee-scales/products/pearl) - [Tested]
 * [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/?coupon=gaggiuino) - [Tested]
+* [Varia AKU](https://www.variabrewing.com/products/varia-aku-scale) - [Untested]
+* [Varia AKU Mini](https://www.variabrewing.com/products/varia-aku-mini-scale) - [Tested]
 
 *__There is a big possibility other acaia models work out of the box as well but thye have not ben tested!__*
 

--- a/src/scales/varia.cpp
+++ b/src/scales/varia.cpp
@@ -1,0 +1,203 @@
+#include "varia.h"
+#include "remote_scales_plugin_registry.h"
+
+const NimBLEUUID serviceUUID("FFF0");
+const NimBLEUUID weightCharacteristicUUID("FFF1");
+const NimBLEUUID commandCharacteristicUUID("FFF2");
+
+//-----------------------------------------------------------------------------------/
+//---------------------------        PUBLIC       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+
+VariaScales::VariaScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool VariaScales::connect() {
+  if (clientIsConnected()) {
+    log("Already connected\n");
+    return true;
+  }
+
+  if (!clientConnect()) {
+    clientCleanup();
+    return false;
+  }
+
+  if (!fetchServices()) {
+    return false;
+  }
+
+  setWeight(0.f);
+
+  subscribeToNotifications();
+
+  return true;
+}
+
+void VariaScales::disconnect() {
+  clientCleanup();
+}
+
+bool VariaScales::isConnected() {
+  return clientIsConnected();
+}
+
+bool VariaScales::tare() {
+  if (!isConnected()) return false;
+  log("Sending tare command\n");
+  uint8_t cmd = static_cast<uint8_t>(VariaMessageType::TARE);
+  uint8_t payload[] = { cmd, 0x01, 0x01 };
+  sendMessage(VariaMessageType::SYSTEM, payload, sizeof(payload));
+  return true;
+};
+
+//-----------------------------------------------------------------------------------/
+//---------------------------       PRIVATE       -----------------------------------/
+//-----------------------------------------------------------------------------------/
+
+bool VariaScales::fetchServices() {
+  service = clientGetService(serviceUUID);
+  if (service != nullptr) {
+    log("Got Service\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  weightCharacteristic = service->getCharacteristic(weightCharacteristicUUID);
+  commandCharacteristic = service->getCharacteristic(commandCharacteristicUUID);
+  if (weightCharacteristic != nullptr && commandCharacteristic != nullptr) {
+    log("Got Weight and Command Characteristics\n");
+  }
+  else {
+    clientCleanup();
+    return false;
+  }
+
+  return true;
+}
+
+void VariaScales::subscribeToNotifications() {
+  auto callback = [this](NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* data, size_t length, bool isNotify) {
+    notifyCallback(pRemoteCharacteristic, data, length, isNotify);
+  };
+
+  if (weightCharacteristic->canNotify()) {
+    log("Registering callback for weight characteristic\n");
+    weightCharacteristic->subscribe(true, callback);
+  }
+}
+
+void VariaScales::sendMessage(VariaMessageType msgType, const uint8_t* payload, size_t payloadLen, bool waitResponse) {
+  uint8_t checksum = payload[0];
+  for (size_t i = 1; i < payloadLen; i++) {
+    checksum ^= payload[i];
+  }
+
+  const size_t msgLen = 1 + payloadLen + 1;
+
+  auto bytes = std::make_unique<uint8_t[]>(msgLen);
+
+  bytes[0] = static_cast<uint8_t>(msgType);
+  memcpy(bytes.get()+1, payload, payloadLen);
+  bytes[msgLen - 1] = checksum;
+
+  commandCharacteristic->writeValue(bytes.get(), msgLen, waitResponse);
+}
+
+void VariaScales::notifyCallback(NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* data, size_t length, bool isNotify) {
+  if(length < 2) {
+    log("Notified message too short, expected at least 2 bytes, got: %s\n", byteArrayToHexString(data, length).c_str());
+    return;
+  }
+  if(data[0] != static_cast<uint8_t>(VariaMessageType::SYSTEM)) {
+    log("Only system tyep message notifications are supported: %s\n", byteArrayToHexString(data, length).c_str());
+    return;
+  }
+
+  // log("Debug message: %s\n", byteArrayToHexString(data, length).c_str());
+
+  while(length > 0) {
+    VariaMessageType messageType = static_cast<VariaMessageType>(data[1]);
+
+    switch(messageType) {
+    case VariaMessageType::WEIGHT:
+    {
+      // [FA 01] 03 10 02 CD {DD}
+      const size_t msgLen = 7;
+      if(! validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      int sign = (data[3] & 0x10) == 0 ? 1 : -1;
+      int value = ((data[3] & 0x0f) << 16) + (data[4] << 8) + data[5];
+      setWeight(sign * value * 0.01f);
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    case VariaMessageType::TIMER:
+    {
+      // [FA 87] 02 00 02 {87}
+      const size_t msgLen = 6;
+      if(!validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      timerSeconds = (data[3] << 8) + data[4];
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    case VariaMessageType::TIMER_START:
+    case VariaMessageType::TIMER_STOP:
+    case VariaMessageType::TIMER_RESET:
+    {
+      // [FA 88] 01 01 {88}
+      // [FA 89] 01 02 {8A}
+      // [FA 8A] 01 03 {88}
+      const size_t msgLen = 5;
+      if(!validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      log("Timer event: %02x\n", data[1]);
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    case VariaMessageType::BATTERY:
+    {
+      // [FA 85] 01 4B {CF}
+      const size_t msgLen = 5;
+      if(!validNotifiedMessage(data, length, msgLen)) {
+        log("Invalid message of type %02x: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+        return;
+      }
+      batteryPercent = data[3];
+      data += msgLen;
+      length -= msgLen;
+      break;
+    }
+    default:
+      // log("Unknown message type %02X: %s\n", messageType, byteArrayToHexString(data, length).c_str());
+      return;
+    }
+  }
+}
+
+bool VariaScales::validNotifiedMessage(uint8_t* data, size_t length, size_t expectedLength) {
+  if(length < expectedLength) {
+    return false;
+  }
+
+  const size_t xorFirst = 1;
+  const size_t xorLast = expectedLength - 2;
+  const size_t xorExpected = expectedLength - 1;
+
+  uint8_t sum = data[xorFirst];
+  for(size_t idx = xorFirst+1; idx <= xorLast; idx++) {
+    sum ^= data[idx];
+  }
+  return sum == data[xorExpected];
+}

--- a/src/scales/varia.cpp
+++ b/src/scales/varia.cpp
@@ -107,15 +107,13 @@ void VariaScales::sendMessage(VariaMessageType msgType, const uint8_t* payload, 
 
 void VariaScales::notifyCallback(NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* data, size_t length, bool isNotify) {
   if(length < 2) {
-    log("Notified message too short, expected at least 2 bytes, got: %s\n", byteArrayToHexString(data, length).c_str());
+    log("notifyCallback: message too short, expected at least 2 bytes, got: %s\n", byteArrayToHexString(data, length).c_str());
     return;
   }
   if(data[0] != static_cast<uint8_t>(VariaMessageType::SYSTEM)) {
-    log("Only system type message notifications are supported: %s\n", byteArrayToHexString(data, length).c_str());
+    log("notifyCallback: Only system type messages are supported: %s\n", byteArrayToHexString(data, length).c_str());
     return;
   }
-
-  // log("Debug message: %s\n", byteArrayToHexString(data, length).c_str());
 
   while(length > 0) {
     VariaMessageType messageType = static_cast<VariaMessageType>(data[1]);

--- a/src/scales/varia.cpp
+++ b/src/scales/varia.cpp
@@ -111,7 +111,7 @@ void VariaScales::notifyCallback(NimBLERemoteCharacteristic* pRemoteCharacterist
     return;
   }
   if(data[0] != static_cast<uint8_t>(VariaMessageType::SYSTEM)) {
-    log("Only system tyep message notifications are supported: %s\n", byteArrayToHexString(data, length).c_str());
+    log("Only system type message notifications are supported: %s\n", byteArrayToHexString(data, length).c_str());
     return;
   }
 

--- a/src/scales/varia.h
+++ b/src/scales/varia.h
@@ -1,0 +1,63 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <Arduino.h>
+
+enum class VariaMessageType : uint8_t {
+  SYSTEM = 0xFA,
+  WEIGHT = 0x01,
+  TARE = 0x82,
+  BATTERY = 0x85,
+  TIMER = 0x87,
+  TIMER_START = 0x88,
+  TIMER_STOP = 0x89,
+  TIMER_RESET = 0x8a,
+};
+
+class VariaScales : public RemoteScales {
+
+public:
+  VariaScales(const DiscoveredDevice& device);
+  void update() override {};
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  bool tare() override;
+
+private:
+  NimBLERemoteService* service;
+  NimBLERemoteCharacteristic* weightCharacteristic;
+  NimBLERemoteCharacteristic* commandCharacteristic;
+
+  int batteryPercent = 0;
+  int timerSeconds = 0;
+
+  bool fetchServices();
+  void subscribeToNotifications();
+
+  void sendMessage(VariaMessageType msgType, const uint8_t* payload, size_t length, bool waitResponse = false);
+  void notifyCallback(NimBLERemoteCharacteristic* pBLERemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify);
+
+  bool validNotifiedMessage(uint8_t* data, size_t length, size_t expectedLength);
+};
+
+class VariaScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-varia",
+      .handles = [](const DiscoveredDevice& device) { return VariaScalesPlugin::handles(device); },
+      .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> { return std::make_unique<VariaScales>(device); },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    return !deviceName.empty() &&
+      (
+        deviceName.find("AKU MINI SCALE") == 0 ||
+        deviceName.find("VARIA AKU") == 0
+      );
+  }
+};

--- a/src/scales/varia.h
+++ b/src/scales/varia.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "remote_scales.h"
 #include "remote_scales_plugin_registry.h"
-#include <Arduino.h>
 
 enum class VariaMessageType : uint8_t {
   SYSTEM = 0xFA,
@@ -25,9 +24,9 @@ public:
   bool tare() override;
 
 private:
-  NimBLERemoteService* service;
-  NimBLERemoteCharacteristic* weightCharacteristic;
-  NimBLERemoteCharacteristic* commandCharacteristic;
+  NimBLERemoteService* service = nullptr;
+  NimBLERemoteCharacteristic* weightCharacteristic = nullptr;
+  NimBLERemoteCharacteristic* commandCharacteristic = nullptr;
 
   int batteryPercent = 0;
   int timerSeconds = 0;


### PR DESCRIPTION
Pretty straight forward.

Aku mini is tested, but also includes the device name match for other aku scales with identical implementation ([per Beanconq](https://github.com/graphefruit/Beanconqueror/blob/master/src/classes/devices/variaAku.ts))

* Battery state and Timer events implemented but just stored/logged.
* Couldn't get anything to appear with a matchable name without changing the scan to active, but that could just be my board - not included in this diff, obvs.